### PR TITLE
fix(config): add sharing_manager to writers list

### DIFF
--- a/game/dojo_dev.toml
+++ b/game/dojo_dev.toml
@@ -31,4 +31,5 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
   "dojo_starter-ownership_manager",
   "dojo_starter-mining_manager",
   "dojo_starter-world_gen_manager",
+  "dojo_starter-sharing_manager",
 ]

--- a/game/dojo_release.toml
+++ b/game/dojo_release.toml
@@ -31,4 +31,5 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
   "dojo_starter-ownership_manager",
   "dojo_starter-mining_manager",
   "dojo_starter-world_gen_manager",
+  "dojo_starter-sharing_manager",
 ]


### PR DESCRIPTION
## Problem

The `sharing_manager` contract cannot execute `upsert_resource_policy` or other sharing operations because it lacks WRITER permissions on the `Adventurer` model.

**Error:**
```
sharing_manager does NOT have WRITER role on model Adventurer
```

## Solution

Add `dojo_starter-sharing_manager` to the `[writers]` list in both `dojo_dev.toml` and `dojo_release.toml`.

This enables the resource sharing/permissions system to:
- Set up resource policies on areas
- Grant access to other adventurers for mining/harvesting
- Manage share rules for yield distribution

## Changes
- `game/dojo_dev.toml`: Added sharing_manager to writers
- `game/dojo_release.toml`: Added sharing_manager to writers

## Testing
After redeployment, the following should work:
```bash
sozo execute dojo_starter-sharing_manager upsert_resource_policy <adventurer_id> <resource_key> <kind> <enabled>
```